### PR TITLE
Release/0.4.2

### DIFF
--- a/docs/source/cliasi_instance.rst
+++ b/docs/source/cliasi_instance.rst
@@ -9,6 +9,20 @@ communicate different program scopes.
 Part A of your program has one instance with its own prefix
 while part B has another instance with a different prefix.
 
+.. code-block:: python
+
+    from cliasi import Cliasi
+
+    def scope_1():
+        cli = Cliasi("scope_1")
+        cli.success("Message will be prefixed with [scope_1]")
+
+    def scope_2():
+        cli = Cliasi("scope_2")
+        cli.warning("Message will be prefixed with [scope_2]")
+
+Global inference
+"""""""""""""""""
 :attr:`~cliasi.cliasi.Cliasi.min_verbose_level` **and**
 :attr:`~cliasi.cliasi.Cliasi.messages_stay_in_one_line`
 are inferred from the global (:data:`cliasi.cli`) instance if not set (None).
@@ -44,3 +58,58 @@ all other instances will inherit these settings unless you explicitly set them.
     <span style="color: #ffffff; font-weight: bold">i</span> <span style="color: #888888">[FUNC]</span> </span><span>| Info from function
     </pre></div>
     </div>
+
+Common mistakes
+"""""""""""""""""
+Please beware that if you have something like this in one of your files:
+
+.. code-block:: python
+    :caption: database_module.py
+
+    from cliasi import Cliasi
+
+    cli = Cliasi("DB")
+    def initialize_database():
+        pass
+
+And maybe get the verbosity level from some config file / as arguments
+and set the level after importing the module like this:
+
+.. code-block:: python
+    :caption: main_program.py
+
+    from cliasi import cli
+    from databasee_module import initialize_database
+
+    def main():
+        cli.min_verbose_level = 2  # Only warnings and errors
+        initialize_database()
+
+The Cliasi instance in database **will not infer** the verbosity level from the global instance
+as it is created before the global instance's verbosity level is set.
+
+To avoid this, either set the verbosity level before importing any modules that create their own Cliasi instances
+or create Cliasi instances only in functions / after the global instance's settings are done.
+
+Below are fixed versions of the above code snippets:
+
+.. code-block:: python
+    :caption: main_program_fixed.py
+
+    from cliasi import cli
+
+    def main():
+        cli.min_verbose_level = 2  # Only warnings and errors
+        from databasee_module import initialize_database
+        initialize_database()
+
+.. code-block:: python
+    :caption: database_module_fixed.py
+
+    from cliasi import Cliasi
+
+    cli: Cliasi
+
+    def initialize_database():
+        cli = Cliasi("DB")
+        pass

--- a/docs/source/cliasi_instance.rst
+++ b/docs/source/cliasi_instance.rst
@@ -79,7 +79,7 @@ and set the level after importing the module like this:
     :caption: main_program.py
 
     from cliasi import cli
-    from databasee_module import initialize_database
+    from database_module import initialize_database
 
     def main():
         cli.min_verbose_level = 2  # Only warnings and errors
@@ -89,7 +89,9 @@ The Cliasi instance in database **will not infer** the verbosity level from the 
 as it is created before the global instance's verbosity level is set.
 
 To avoid this, either set the verbosity level before importing any modules that create their own Cliasi instances
-or create Cliasi instances only in functions / after the global instance's settings are done.
+or create Cliasi instances only in functions / after the global instance's settings have been set.
+
+You can also use the :meth:`~cliasi.cliasi.Cliasi.infer_settings` method to manually infer the settings from the global instance.
 
 Below are fixed versions of the above code snippets:
 
@@ -100,7 +102,7 @@ Below are fixed versions of the above code snippets:
 
     def main():
         cli.min_verbose_level = 2  # Only warnings and errors
-        from databasee_module import initialize_database
+        from database_module import initialize_database
         initialize_database()
 
 .. code-block:: python
@@ -108,8 +110,8 @@ Below are fixed versions of the above code snippets:
 
     from cliasi import Cliasi
 
-    cli: Cliasi
+    cli: Cliasi = Cliasi("DB")
 
     def initialize_database():
-        cli = Cliasi("DB")
+        cli.infer_settings()
         pass

--- a/docs/source/cliasi_instance.rst
+++ b/docs/source/cliasi_instance.rst
@@ -21,6 +21,23 @@ while part B has another instance with a different prefix.
         cli = Cliasi("scope_2")
         cli.warning("Message will be prefixed with [scope_2]")
 
+Instance options
+"""""""""""""""""
+Every cliasi instance has the following parameters / methods:
+
+* :meth:`~cliasi.cliasi.Cliasi.set_prefix()` - to set the prefix for every message from this instance
+* :meth:`~cliasi.cliasi.Cliasi.infer_settings()` - to infer settings like the ones below from the global instance, see :ref:`global_inference`
+* :attr:`~cliasi.cliasi.Cliasi.enable_colors` - whether to use colored output for this instance
+* :attr:`~cliasi.cliasi.Cliasi.max_dead_space` - maximum number of empty space between aligned messages for this instance. See :ref:`max_dead_space`
+* :attr:`~cliasi.cliasi.Cliasi.min_verbose_level` - verbosity level for this instance
+* :attr:`~cliasi.cliasi.Cliasi.messages_stay_in_one_line` - whether messages should stay in one line for this instance
+
+.. note::
+    ``messages_stay_in_one_line`` does not affect progress bars, animations and messages
+    that go over multiple lines due to API limitations.
+
+.. _global_inference:
+
 Global inference
 """""""""""""""""
 :attr:`~cliasi.cliasi.Cliasi.min_verbose_level` **and**

--- a/docs/source/message_types.rst
+++ b/docs/source/message_types.rst
@@ -70,8 +70,12 @@ Animations and Progress Bars
 ----------------------------
 
 Blocking Animation
-"""""""""""""""""""""
+""""""""""""""""""""""""""""""
 Blocking animations run in the main thread and block further execution until complete.
+
+.. note::
+    Animated messages trim overflowing text to the current terminal width as animations only
+    work when the text is one line long.
 
 .. code-block:: python
     :caption: examples/blocking_animation.py
@@ -128,7 +132,11 @@ Non-Blocking Animation
    </div>
 
 Progress Bars
-""""""""""""""""""
+"""""""""""""""""""""
+
+.. note::
+    Progress bars (animated and static) trim overflowing text to the current terminal width.
+    They work when the text is one line long.
 
 .. code-block:: python
     :caption: examples/progress_bar.py
@@ -157,7 +165,7 @@ Progress Bars
 
 
 Animated Progress Bars
-""""""""""""""""""""""""""
+""""""""""""""""""""""""""""""
 .. code-block:: python
     :caption: examples/animated_progress_bar.py
 

--- a/src/cliasi/cliasi.py
+++ b/src/cliasi/cliasi.py
@@ -65,7 +65,7 @@ class Cliasi:
     def __init__(
         self,
         prefix: str = "",
-            messages_stay_in_one_line: bool | None = None,
+        messages_stay_in_one_line: bool | None = None,
         colors: bool = True,
         min_verbose_level: int | None = None,
         seperator: str = "|",
@@ -1541,7 +1541,7 @@ class Cliasi:
         interval: int | float = 0.25,
         unicorn: bool = False,
         messages_stay_in_one_line: bool | None = None,
-    ) -> NonBlockingAnimationTask | None:
+    ) -> NonBlockingAnimationTask:
         """
         Display a loading animation in the background
         Stop animation by calling .stop() on the returned object
@@ -1598,7 +1598,7 @@ class Cliasi:
         interval: int | float = 0.25,
         unicorn: bool = False,
         messages_stay_in_one_line: bool | None = True,
-    ) -> NonBlockingAnimationTask | None:
+    ) -> NonBlockingAnimationTask:
         """
         Display a downloading animation in the background
 

--- a/src/cliasi/cliasi.py
+++ b/src/cliasi/cliasi.py
@@ -118,6 +118,14 @@ class Cliasi:
             3 + len(self.__prefix) + len(self.__prefix_seperator)
         )
 
+    def infer_settings(self) -> None:
+        """
+        Infer settings from the global cli instance.
+
+        """
+        self.min_verbose_level = cli.min_verbose_level
+        self.messages_stay_in_one_line = cli.messages_stay_in_one_line
+
     def set_seperator(self, seperator: str) -> None:
         """
         Set the seperator between prefix and message

--- a/src/cliasi/cliasi.py
+++ b/src/cliasi/cliasi.py
@@ -233,9 +233,10 @@ class Cliasi:
             # Nothing to print
             return None
         # content_space - separating space (needed to separate left, right etc)
-        if (content_space - separating_space) < len(
+        force_multiline = (content_space - separating_space) < len(
             content_total
-        ) or "\n" in content_total:
+        ) or "\n" in content_total
+        if force_multiline:
             # Can't print in one line.
             content_to_split = ""
             if isinstance(message_left, str):
@@ -382,7 +383,9 @@ class Cliasi:
             for line in lines:
                 index += 1
                 is_last = index == len(lines)
-                end_str = ("" if (oneline and is_last) else "\n") + TextColor.RESET
+                end_str = (
+                    "" if (oneline and not force_multiline and is_last) else "\n"
+                ) + TextColor.RESET
 
                 if index == 1:
                     # Printing first / last line
@@ -896,14 +899,28 @@ class Cliasi:
         :param current_animation_frame: Current animation frame to show
         :return: None
         """
-        self.__print(
-            color,
-            current_symbol_frame,
+        base_message = (
             current_animation_frame
             + ("" if current_animation_frame == "" else " ")
             + message_left
             if isinstance(message_left, str)
-            else "",
+            else current_animation_frame
+        )
+        available = max(
+            1,
+            _terminal_size()
+            - (self.__space_before_message + len(current_symbol_frame) + 1),
+        )
+        if len(base_message) > available:
+            if available > 1:
+                base_message = base_message[: available - 1] + "…"
+            else:
+                base_message = base_message[:available]
+
+        self.__print(
+            color,
+            current_symbol_frame,
+            base_message,
             True,
             message_center=message_center,
             message_right=message_right,


### PR DESCRIPTION
Fix animated messages going over multiple lines

* Auto-truncate messages too long
* Fix issue where multiline message would get only its last line replaced. Will now always print multiline message with stays_in_one_line = False
* Add common mistakes section to cliasi_instance.rst
* Update documentation with new auto-truncate behaviour
* Add tests